### PR TITLE
Include the awesome-pages plugin

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install MKdocs and theme
         run: |
           pip install mkdocs-material
+          pip install mkdocs-awesome-pages-plugin
+          pip install mkdocs-mermaid2-plugin
+          pip install mkdocs-git-revision-date-localized-plugin
       
       - name: Deploy MKdocs site
         run: |

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,5 +1,5 @@
 nav:
-- Onboarding.md
+- Index.md
 - Ways-of-Working: 2.-Ways-of-Working
 - Delivery-Framework: 3.-Delivery-Framework
 - Delivery-Practices: 4.-Delivery-Practices

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,7 @@
+nav:
+- Onboarding.md
+- Ways-of-Working: 2.-Ways-of-Working
+- Delivery-Framework: 3.-Delivery-Framework
+- Delivery-Practices: 4.-Delivery-Practices
+- Department-Policies: 5.-Department-Policies
+- Playbook-User-Guide: 6.-Playbook-User-Guide

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-title: 1. Home
 Authors: 
 - Ed Earle
 Created: 2022-01-19

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,11 @@ extra_css:
   - stylesheets/extra.css
 extra_javascript:
   - https://unpkg.com/mermaid@9.3.0/dist/mermaid.min.js
+plugins:
+  - search
+  - mermaid2
+  - git-revision-date-localized
+  - awesome-pages
 theme:
   logo: assets/images/AM no tag.png
   name: material
@@ -19,10 +24,6 @@ theme:
     - navigation.indexes
     #- navigation.tabs
     #- navigation.tabs.sticky
-  plugins:
-    - search
-    - mermaid2
-    - git-revision-date-localized
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: AM      


### PR DESCRIPTION
Fix plugin configuration and installation by:
- Explicitly installing used plugins in the `publish-site.yml` workflow
- Moving the `plugins:` YML block to the root of the `mkdocs.yml` file

Install the **awesome-pages** plugin, and add a sample `.pages` file in the root of the `docs` folder, which allows configuration of page nav order.

If approved, a future PR could then rename all the folders to remove the numbering, and add in `.pages` files where necessary to preserve desired ordering.