### PR TITLE
Investigate link checker & fix a bunch of links

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -1,0 +1,20 @@
+name: Check for Broken Links
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    name: Check for Broken links
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Check for broken links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: yes
+          folder-path: docs
+          config-file: broken-links.json

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -1,7 +1,7 @@
 name: Check for Broken Links
 
 on:
-  #pull_request:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -1,7 +1,7 @@
 name: Check for Broken Links
 
 on:
-  pull_request:
+  #pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -7,29 +7,40 @@ on:
       - main
 
 jobs:
-  documentation:
-    name: Build site
+  check-links:
+    name: Check for Broken links
     runs-on: ubuntu-latest
     steps:
 
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check for broken links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
 
-      - name: Install MKdocs and theme
-        run: |
-          pip install mkdocs-material
-          pip install mkdocs-awesome-pages-plugin
+  # documentation:
+  #   name: Build site
+  #   needs: check-links
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v2
+
+  #     - name: Install MKdocs and theme
+  #       run: |
+  #         pip install mkdocs-material
+  #         pip install mkdocs-awesome-pages-plugin
       
-      - name: Deploy MKdocs site
-        run: |
-          mkdocs build
+  #     - name: Deploy MKdocs site
+  #       run: |
+  #         mkdocs build
 
-      - name: Deploy via FTP
-        uses: SamKirkland/FTP-Deploy-Action@4.3.2
-        with:
-          server: ${{ secrets.FTP_TARGET }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          server-dir: site/wwwroot/
-          local-dir: ./site/
-          protocol: ftps
+  #     - name: Deploy via FTP
+  #       uses: SamKirkland/FTP-Deploy-Action@4.3.2
+  #       with:
+  #         server: ${{ secrets.FTP_TARGET }}
+  #         username: ${{ secrets.FTP_USERNAME }}
+  #         password: ${{ secrets.FTP_PASSWORD }}
+  #         server-dir: site/wwwroot/
+  #         local-dir: ./site/
+  #         protocol: ftps

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Check for broken links
         uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: yes
+          folder-path: docs
+          config-file: broken-links.json
 
   # documentation:
   #   name: Build site

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -7,44 +7,29 @@ on:
       - main
 
 jobs:
-  check-links:
-    name: Check for Broken links
+  documentation:
+    name: Build site
     runs-on: ubuntu-latest
     steps:
 
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check for broken links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: yes
-          folder-path: docs
-          config-file: broken-links.json
 
-  # documentation:
-  #   name: Build site
-  #   needs: check-links
-  #   runs-on: ubuntu-latest
-  #   steps:
-
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v2
-
-  #     - name: Install MKdocs and theme
-  #       run: |
-  #         pip install mkdocs-material
-  #         pip install mkdocs-awesome-pages-plugin
+      - name: Install MKdocs and theme
+        run: |
+          pip install mkdocs-material
+          pip install mkdocs-awesome-pages-plugin
       
-  #     - name: Deploy MKdocs site
-  #       run: |
-  #         mkdocs build
+      - name: Deploy MKdocs site
+        run: |
+          mkdocs build
 
-  #     - name: Deploy via FTP
-  #       uses: SamKirkland/FTP-Deploy-Action@4.3.2
-  #       with:
-  #         server: ${{ secrets.FTP_TARGET }}
-  #         username: ${{ secrets.FTP_USERNAME }}
-  #         password: ${{ secrets.FTP_PASSWORD }}
-  #         server-dir: site/wwwroot/
-  #         local-dir: ./site/
-  #         protocol: ftps
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@4.3.2
+        with:
+          server: ${{ secrets.FTP_TARGET }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          server-dir: site/wwwroot/
+          local-dir: ./site/
+          protocol: ftps

--- a/broken-links.json
+++ b/broken-links.json
@@ -13,14 +13,6 @@
         {
             "pattern": "%26",
             "replacement": "&"
-        },
-        {
-            "pattern": "/$",
-            "replacement": ".md"
-        },
-        {
-            "pattern": "[^.md]$",
-            "replacement": ".md"
         }
     ]
 }

--- a/broken-links.json
+++ b/broken-links.json
@@ -20,7 +20,7 @@
         },
         {
             "pattern": "[^.md]$",
-            "replacement": "$1.md"
+            "replacement": ".md"
         }
     ]
 }

--- a/broken-links.json
+++ b/broken-links.json
@@ -1,7 +1,22 @@
 {
     "ignorePatterns":[
         { "pattern": "^https://" },
+        { "pattern": "^http://localhost" },
         { "pattern": "^https://github.com" },
         { "pattern": "^https://docs.github.com" }
+    ],
+    "replacementPatterns": [
+        {
+            "pattern": "%2D",
+            "replacement": "-"
+        },
+        {
+            "pattern": "%26",
+            "replacement": "&"
+        },
+        {
+            "pattern": "/$",
+            "replacement": ".md"
+        }
     ]
 }

--- a/broken-links.json
+++ b/broken-links.json
@@ -17,6 +17,10 @@
         {
             "pattern": "/$",
             "replacement": ".md"
+        },
+        {
+            "pattern": "[^.md]$",
+            "replacement": "$1.md"
         }
     ]
 }

--- a/broken-links.json
+++ b/broken-links.json
@@ -1,0 +1,5 @@
+{
+    "ignorePatterns":[
+        { "pattern": "^https://github.com" }
+    ]
+}

--- a/broken-links.json
+++ b/broken-links.json
@@ -3,9 +3,7 @@
         { "pattern": "^https://" },
         { "pattern": "^http://localhost" },
         { "pattern": "^https://github.com" },
-        { "pattern": "^https://docs.github.com" },
-        { "pattern": "/$" },
-        { "pattern": ".md$" }
+        { "pattern": "^https://docs.github.com" }
     ],
     "replacementPatterns": [
         {

--- a/broken-links.json
+++ b/broken-links.json
@@ -1,5 +1,7 @@
 {
     "ignorePatterns":[
-        { "pattern": "^https://github.com" }
+        { "pattern": "^https://" },
+        { "pattern": "^https://github.com" },
+        { "pattern": "^https://docs.github.com" }
     ]
 }

--- a/broken-links.json
+++ b/broken-links.json
@@ -3,7 +3,9 @@
         { "pattern": "^https://" },
         { "pattern": "^http://localhost" },
         { "pattern": "^https://github.com" },
-        { "pattern": "^https://docs.github.com" }
+        { "pattern": "^https://docs.github.com" },
+        { "pattern": "/$" },
+        { "pattern": ".md$" }
     ],
     "replacementPatterns": [
         {

--- a/docs/Delivery-Framework/Ideation-and-Discovery/Technology-Vision-and-Strategy/index.md
+++ b/docs/Delivery-Framework/Ideation-and-Discovery/Technology-Vision-and-Strategy/index.md
@@ -34,4 +34,4 @@ next-review: 2022-01-04
 - Our **Technology Strategy** describes what we aim to achieve in mid-to-long term, in line with our guiding vision  
 - The Technology Strategy informs our **Tech Roadmap**, a set of high level outcomes, which are broken down into discrete deliverables to form our **Backlog**.
 - This sits alongside our Product and Support visions, strategies, roadmaps and backlogs
-- Our [departmental mission](/1.-Welcome/Mission) links them together.
+- Our [departmental mission](#our-mission) links them together.

--- a/docs/Delivery-Framework/index.md
+++ b/docs/Delivery-Framework/index.md
@@ -12,9 +12,9 @@ next-review: 2022-04-01
 
 Our agile Delivery Framework is designed as a robust and clear abstract mechanism by which value is derived, delivered, and maintained by the organisation.
 
-This delivery framework describes at a high level our [value stream](../Ways-of-Working/1.-Flow/#value-stream-mapping).
+This delivery framework describes at a high level our [value stream](../Ways-of-Working/Flow/#value-stream-mapping).
 
-While the high-level framework itself is fixed, the [delivery practices](../Delivery-Practices/) that live within it should be constantly evolving, such that the framework continues to support [our mission](/1.-Welcome/Mission).
+While the high-level framework itself is fixed, the [delivery practices](../Delivery-Practices/) that live within it should be constantly evolving, such that the framework continues to support [our mission](#our-mission).
 
 ```mermaid
 

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Documenation/Readme-files-in-code-repositories.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Documenation/Readme-files-in-code-repositories.md
@@ -181,7 +181,7 @@ We use [Swashbuckle](https://learn.microsoft.com/en-us/aspnet/core/tutorials/get
 
 When making changes to this repository, ensure that: 
 
-- You follow the branching strategy outlined in [Playbook](https://amdigital-co-uk.github.io/6.-Engineering/Source-Control%2C-Versioning-%26-Branching-Strategy/#branching-strategy)
+- You follow the branching strategy outlined in [Playbook](https://amdigital-co-uk.github.io/Engineering/Source-Control%2C-Versioning-%26-Branching-Strategy/#branching-strategy)
 - No code is touched before failing tests are written
 - There is a preference for integration tests over unit tests (where pragmatic)
 ```

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing/Performing-a-Peer-Review.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing/Performing-a-Peer-Review.md
@@ -11,7 +11,7 @@ next*review: 2022-04-01
 The engineer performing the review must:
 
 * Copy and paste the template checklist (below) into their a new comment on the PR in GitHub
-* Start reviewing the changes with respect to the [Quality Standards](/6.*Engineering/Quality*Standards)
+* Start reviewing the changes with respect to the [Quality Standards](../Quality*Standards)
 * When the reviewer is happy that a particular guideline has been met, the relevant item in the checklist is checked
 * If any guidelines are **not** met, the reviewer should add a comment (either a general comment, or next to the offending portion of code) to explain why
 

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing/index.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing/index.md
@@ -18,7 +18,7 @@ The purpose of a peer review is to identify mistakes as early as possible and en
 
 Peer reviewing must not be left until last minute, or performed as a one-time event. Instead, we should be working closely with our colleagues to share our approach throughout the development cycle. This allows for early feedback around the way a solution is built, and allows for the reviewer to gain a greater degree of context.
 
-The final stage of peer reviewing is when code is [merged into a parent branch](/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy) (e.g. Work Branch --> Feature Branch, or Feature Branch --> Release Branch). This process allows for in depth reviewing of the full solution.
+The final stage of peer reviewing is when code is [merged into a parent branch](/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy) (e.g. Work Branch --> Feature Branch, or Feature Branch --> Release Branch). This process allows for in depth reviewing of the full solution.
 
 ## Pair Programming & WIP Reviewing
 
@@ -45,6 +45,6 @@ A review should still be performed for any code written during a pair programmin
 
 It is best to submit code to be reviewed frequently, both to get early feedback and to ensure that the reviewing engineer can get a good picture of the changes without being overwhelmed by a huge amount of changes all at once. In other words, follow the principle of little and often!
 
-When submitting a PR the engineer should follow the [Pull Request Guidelines](/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy/Pull-Requests), and should ensure to provide some context of what the code being reviewed is try to achieve and how it is structured.
+When submitting a PR the engineer should follow the [Pull Request Guidelines](/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Pull-Requests), and should ensure to provide some context of what the code being reviewed is try to achieve and how it is structured.
 
 If refactoring existing code (in preparation for subsequent changes), the refactoring should be performed separately and submitted for review in isolation. It would otherwise be much harder for the reviewing engineer to understand how the refactoring has been done if there are also additional changes and new functionality mixed in.

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Quality-Standards/index.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Quality-Standards/index.md
@@ -41,11 +41,11 @@ This is why it is important to share our approach to solutions early! Peer revie
 
 ## Readable and Maintainable
 
-First and foremost, high-quality code must be easy to read and understand. Code must also follow our in-house [coding conventions](/6.-Engineering/Quality-Standards/Coding-Conventions). The names of methods and classes etc. must clearly indicate what they do, and methods and classes must not be too lengthy.
+First and foremost, high-quality code must be easy to read and understand. Code must also follow our in-house [coding conventions](/Delivery-Practices/Build-and-Release/Engineering/Quality-Standards/Coding-Conventions). The names of methods and classes etc. must clearly indicate what they do, and methods and classes must not be too lengthy.
 
 Code must also follow the [SOLID principles](https://www.youtube.com/watch?v=pTB30aXS77U), which will help to make it better structured, more readable and keep methods and classes manageable sizes.
 
-When creating new endpoints on microservices, ensure that they follow the [endpoint naming conventions](/6.-Engineering/Quality-Standards/Endpoint-Naming-Conventions).
+When creating new endpoints on microservices, ensure that they follow the [endpoint naming conventions](/Delivery-Practices/Build-and-Release/Engineering/Quality-Standards/Endpoint-Naming-Conventions).
 
 Making code more _maintainable_ is effectively the practice of minimising the amount of times you have to _update_ it. Avoid using hardcoded values in code, as these values can only be changed by changing the code. Instead, consider making the behaviour of the code configurable by offloading these values to configuration.
 
@@ -56,7 +56,7 @@ Do not commit commented-out code. It makes code less readable, and also causes c
 
 ## Unit & Integration Tests
 
-Code must be well covered by [unit & integration tests](/6.-Engineering/Quality-Standards/Unit-&-Integration-Testing). Unit & integration testing not only increases our chances of catching bugs, increases engineer confidence in any changes being made, but is also an indication that the code is well-structured.
+Code must be well covered by [unit & integration tests](/Delivery-Practices/Build-and-Release/Engineering/Quality-Standards/Unit-&-Integration-Testing). Unit & integration testing not only increases our chances of catching bugs, increases engineer confidence in any changes being made, but is also an indication that the code is well-structured.
 
 To meet quality guidelines, all .NET code must be covered by Unit and/or integration tests with the aim of achieving 80% code coverage. For legacy repositories that do not meet this threshold, the aim should be to _increase_ the coverage coverage percentage when writing new code, so as to incrementally meet the desired threshold. For repositories that are already well-tested, all new code must be sufficiently well tested so as to not bring the average coverage down.
 
@@ -75,7 +75,7 @@ Building observable systems enables development engineers to measure how well th
 
 A critical part of this is ensuring that services are logging useful events and errors. Log messages need to contain enough information to help an engineer understand what was happening, including for example Website Key or Client Key, ID of an asset or document affected, action being performed etc.
 
-See more information about [logging in Quartex](/6.-Engineering/Quality-Standards/Logging-Best-Practise), and further reading on general [best practices](https://microsoft.github.io/code-with-engineering-playbook/observability/pillars/logging/#best-practices) for logging.
+See more information about [logging in Quartex](/Delivery-Practices/Build-and-Release/Engineering/Quality-Standards/Logging-Best-Practise), and further reading on general [best practices](https://microsoft.github.io/code-with-engineering-playbook/observability/pillars/logging/#best-practices) for logging.
 
 ## Documentation
 
@@ -94,7 +94,7 @@ Every repository must have a README, which should succinctly explain:
 - Additional steps required to build or debug the code
 - Any processes that are unique to this repository
 
-Further reading on [documentation guidelines](/1.-Welcome/Documentation-Guidelines/Documentation-Guidelines/).
+Further reading on [documentation guidelines](/Welcome/Documentation-Guidelines/Documentation-Guidelines/).
 
 Documentation must never include any passwords or other sensitive configuration. These should be stored and documented in a secure manner, such as in a Password Manager (_TODO - setup password management for division_) or in a Secrets Manager.
 
@@ -134,7 +134,7 @@ The Microsoft article on [.NET Core performance best practices](https://docs.mic
 
 ### General performance tips
 
-Use caching where ever it is possible and appropriate. The Quartex [caching guidelines](/6.-Engineering/Structure-and-Patterns/Caching) contain mechanisms for a range of different types of caching, including the caching service calls for retrieving data, and output caching to cache entire pages. The fastest way of doing work is to not have to do the work at all! 
+Use caching where ever it is possible and appropriate. The Quartex [caching guidelines](/Delivery-Practices/Build-and-Release/Engineering/Structure-and-Patterns/Caching) contain mechanisms for a range of different types of caching, including the caching service calls for retrieving data, and output caching to cache entire pages. The fastest way of doing work is to not have to do the work at all! 
 
 Use `async`/`await` calls wherever possible. The async pattern allows the operatic system to assign idle CPU capacity to a thread that has work to do, instead of keeping the thread busy. Whilst it may be difficult to see much of a difference when developing locally, using `async`/`await` allows a webserver to handle many more requests in parallel.
 

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-&-Versioning-Shared-Code-Repositories.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-&-Versioning-Shared-Code-Repositories.md
@@ -85,8 +85,8 @@ Our [versioning strategy](#versioning) means that every change produces a unique
 1. Each engineer who needs to make changes to a package must create their own **Work** branch off **Main**, against which they can commit all changes. Regular and small [commits](https://git-scm.com/docs/git-commit) are recommended, and should be regularly [pushed](https://git-scm.com/docs/git-push). 
 1. Each commit must be accompanied by a useful description of the change made.
 1. When changes to the package have been completed, and a new version of the package built, the engineer should submit a **Pull Request** back to **Main**.
-    - Follow the [pull request](/6.-Engineering/Peer-Reviewing/Pull-Requests#creating-a-pull-request) instructions
+    - Follow the [pull request](/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing/Pull-Requests#creating-a-pull-request) instructions
     - Fill in the details requested as part of the template pull request
-1. Another member of the team should then perform a [peer review](/6.-Engineering/Peer-Reviewing) on the work
+1. Another member of the team should then perform a [peer review](/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing) on the work
     - Any changes requested as part of the peer review should be committed to the **Work** branch.
 1. When the review is completed (including any agreed changes, as above), the pull request can be merged into **Main**, and new package versions will be automatically created

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-Functions-as-a-Service.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-Functions-as-a-Service.md
@@ -27,7 +27,7 @@ Code is managed and stored using [Git](https://git-scm.com/docs) and GitHub.
 1. Each commit must be accompanied by a useful description of the change made.
 1. If multiple engineers are working concurrently on a single feature, and their work is interdependent (i.e. could not be usefully tested independently), each should use their own **Work** branch and one **Work** branch should be merged into another, via a [pull request (PR)](#merging-and-pull-requestss).
 1. When the engineer has completed their work, and it is ready for testing, a [PR](#merging-and-pull-requestss) can be submitted to merge it into the **Stage** branch.
-1. The [PR](#merging-and-pull-requestss) should be actioned by another member of the team, who should perform a [peer review](/6.-Engineering/Peer-Reviewing) at this time.
+1. The [PR](#merging-and-pull-requestss) should be actioned by another member of the team, who should perform a [peer review](/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing) at this time.
 1. Changes required should be performed by the original engineer against the merging **Work** branch, but any other member of the team should do this in their absence.
 1. When a [PR](#merging-and-pull-requestss) is completed and the **Stage** branch has been updated, a build will be automatically kicked off and the function will be deployed if successful.
 1. When a feature has passed testing and PO review, the **Stage** branch can be merged into the **Main** branch, by performing a [PR](#merging-and-pull-requests).

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Pull-Requests.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Pull-Requests.md
@@ -10,7 +10,7 @@ next-review: 2022-04-01
 
 ## Pull Requests
 
-A pull request (PR) is required when [merging a child branch into a parent](/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy).
+A pull request (PR) is required when [merging a child branch into a parent](/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy).
 
 > **NOTE:** manually merging or committing directly to a parent branch is not permitted. Firstly because it skips the PR mechanism (and therefore bypasses an important quality control step), and secondly because only a PR will trigger the relevant Continuous Integration workflows and builds.
 
@@ -29,7 +29,7 @@ When creating the pull request, the engineer submitting their work should make s
   - Link the request to the relevant **backlog item** in Azure DevOps by adding `AB#123` where 123 is the ID of the backlog item. _NOTE: do not link to individual tasks_.
   - If there are PRs in other repos that are related to the same piece of work, link to them in the PR description (see hints, below)
   - This shouldn't need to be too detailed, as ideally this won't be the first time they are seeing the code
-  - In the case of a shared code repository, provided the information about [version number update](/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-&-Versioning-Shared-Code-Repositories#Versioning) (i.e. MAJOR vs MINOR vs PATCH) and why it is appropriate
+  - In the case of a shared code repository, provided the information about [version number update](/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-&-Versioning-Shared-Code-Repositories#Versioning) (i.e. MAJOR vs MINOR vs PATCH) and why it is appropriate
 - Assign their team as a reviewer
 
 > **NOTE:** the final step will automatically assign all other team members, and only one team member needs to approve the PR. The engineer submitting the PR should communicate with the rest of their team to request a review.

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/index.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/index.md
@@ -15,7 +15,7 @@ Code is managed and stored using [Git](https://git-scm.com/docs) and GitHub.
 
 ## Branching Strategy
 
-**IMPORTANT NOTE:** This strategy applies to all repositions with the **exception of any shared code repositories** which generate NuGet packages which are  dependencies of multiple other repos/solutions. Please see the specific [Branching & Versioning Shared Repositories](/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-&-Versioning-Shared-Code-Repositories) documentation.
+**IMPORTANT NOTE:** This strategy applies to all repositions with the **exception of any shared code repositories** which generate NuGet packages which are  dependencies of multiple other repos/solutions. Please see the specific [Branching & Versioning Shared Repositories](/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy/Branching-&-Versioning-Shared-Code-Repositories) documentation.
 
 | **Branch** | **Key Purpose** | **Naming** |
 |--|--|--|
@@ -32,7 +32,7 @@ Code is managed and stored using [Git](https://git-scm.com/docs) and GitHub.
 1. Each commit must be accompanied by a useful description of the change made.
 1. If multiple engineers are working concurrently on a single feature, and their work is interdependent (i.e. could not be usefully tested independently), each should use their own **Work** branch and one **Work** branch should be merged into another, via a [pull request (PR)](#merging-and-pull-requestss) . 
 1. When the engineer has completed their work, and it is ready for test, a [PR](#merging-and-pull-requestss) can be submitted to merge it into the **Feature** branch.
-1. The [PR](#merging-and-pull-requestss) should be actioned by another member of the team, who should perform a [peer review](/6.-Engineering/Peer-Reviewing) at this time.
+1. The [PR](#merging-and-pull-requestss) should be actioned by another member of the team, who should perform a [peer review](/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing) at this time.
 1. Changes required should be performed by the original engineer against the merging **Work** branch, but any other member of the team should do this in their absence. 
 1. When a [PR](#merging-and-pull-requestss) is completed and the **Feature** branch has been updated, a build will be automatically kicked off and a releasable package created. This can then be deployed into any available QA environment for testing or PO review.
 1. When a feature has passed testing and PO review, the **Feature** branch can be merged into either a **Release** branch, the the **Main** branch, by performing a [PR](#merging-and-pull-requests):
@@ -67,7 +67,7 @@ If you are deploying non-functional changes (such as documentation or linting), 
 ### Merging and Pull Requests
 
 #### Merging Upstream
-Upstream merges occur when changes need to pulled into a parent branch. When this is done, a [Pull Request (PR)](https://git-scm.com/docs/git-request-pull) must be submitted and a [peer review performed](/6.-Engineering/Peer-Reviewing) by another member of the team.
+Upstream merges occur when changes need to pulled into a parent branch. When this is done, a [Pull Request (PR)](https://git-scm.com/docs/git-request-pull) must be submitted and a [peer review performed](/Delivery-Practices/Build-and-Release/Engineering/Peer-Reviewing) by another member of the team.
 
 You should only merge _good work_ upstream. I.e. it should already be known to pass all quality standards and tests.
 

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Test-Engineering/Functional Test Strategy.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Test-Engineering/Functional Test Strategy.md
@@ -85,7 +85,7 @@ There are many different types of software testing techniques, each with its own
 
 ### Supported Browsers & Devices
 
-Please refer to the [Supported Browsers, Devices & Operating Systems](/docs\Engineering\Test-Engineering\Supported-Browsers,-Devices-&-Operating-Systems.md) documentation
+Please refer to the [Supported Browsers, Devices & Operating Systems](Test-Engineering/Supported-Browsers,-Devices-&-Operating-Systems.md) documentation
 
 ## Test Process
 

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Test-Engineering/Functional Test Strategy.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Test-Engineering/Functional Test Strategy.md
@@ -85,7 +85,7 @@ There are many different types of software testing techniques, each with its own
 
 ### Supported Browsers & Devices
 
-Please refer to the [Supported Browsers, Devices & Operating Systems](/docs\6.-Engineering\Test-Engineering\Supported-Browsers,-Devices-&-Operating-Systems.md) documentation
+Please refer to the [Supported Browsers, Devices & Operating Systems](/docs\Engineering\Test-Engineering\Supported-Browsers,-Devices-&-Operating-Systems.md) documentation
 
 ## Test Process
 

--- a/docs/Delivery-Practices/Build-and-Release/Engineering/Test-Environments.md
+++ b/docs/Delivery-Practices/Build-and-Release/Engineering/Test-Environments.md
@@ -94,7 +94,7 @@ The Feature/Change is now ready to be released to Demo & Live.
 
 On completion of the release:
 
-1. Follow the [branching strategy guidelines](/6.-Engineering/Source-Control,-Versioning-&-Branching-Strategy) to ensure the main branch is updated
+1. Follow the [branching strategy guidelines](/Delivery-Practices/Build-and-Release/Engineering/Source-Control,-Versioning-&-Branching-Strategy) to ensure the main branch is updated
 1. The relevant QA environment and Stage (if not being used by another BAT session) must be switched off
 
 ### WorkFlow Diagram

--- a/docs/Delivery-Practices/Build-and-Release/Sprint-Cycle/index.md
+++ b/docs/Delivery-Practices/Build-and-Release/Sprint-Cycle/index.md
@@ -35,7 +35,7 @@ The sprint includes a series of events that occur at the same time each day/spri
 
 Besides the key sprint events, there are other events that may occur periodically:
 - to support the design & definition of future work - currently as Backlog Refinement (although this will be reviewed as the new [3 Amigos](/Platform-Development-Playbook/Backlog-Management/3-Amigos-&-Readying-Backlog-Items) practice is implemented)
-- to plan the runway of work for near future sprints - [Runway planning](/Sprints-&-Teams/Runway-Planning)
+- to plan the runway of work for near future sprints - [Runway planning](/Delivery-Practices/Build-and-Release/Sprint-Cycle//Runway-Planning)
 
 Guidance and details on these events can be found in subpages.
 
@@ -47,13 +47,13 @@ Each team will consist of software engineers, test engineers, and a product mana
 Product Delivery Teams (short hand: "delivery teams") will engage in both "Sprint work"- i.e. building, testing, and releasing product increments - and also preparation work - i.e. the design and definition (aka refinement) of future sprint work. 
 
 ## Product Delivery Team Responsibilities
-Each of these teams has specific responsibilities that align with [our mission](/1.-Welcome/Mission):
+Each of these teams has specific responsibilities that align with [our mission](#our-mission):
 	
 1. Sprint Success		
     - Determining which of the sprint Candidates can be achieved during the sprint, given the available resources and work that needs to be done (considering the Definition of Done), and communicating this to the Enablement Team
     - Planning how this work will be done, including determining what work needs to be done and devising a strategy for completing it
     - Identify blockers and risks that may prevent sprint success, and promptly communicating them to the Enablement Team
-    - Executing the planned work to the [quality standards outlined in the Playbook](/6.-Engineering/Quality-Standards)
+    - Executing the planned work to the [quality standards outlined in the Playbook](/Delivery-Practices/Build-and-Release/Engineering/Quality-Standards)
     - Updating the plan as required, and communicating updates to the Enablement Team
     - Planning and performing releases, and collaborating with the enablement team and other product delivery teams to minimise risk
     - Measuring and reporting on the sprint progress

--- a/docs/Delivery-Practices/Design-and-Definition/Definition-of-Ready/Defining-Features-and-Changes.md
+++ b/docs/Delivery-Practices/Design-and-Definition/Definition-of-Ready/Defining-Features-and-Changes.md
@@ -14,21 +14,21 @@ Ready Features and Change Backlog Items should:
 
 1. Meet [INVEST](https://www.agilealliance.org/glossary/invest/) criteria and 
 1. Include the following artefacts:
-    1. [Problem Statement](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
-    1. [Value Proposition](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
-    1. [Solution Executive Summary](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
-    1. [User Flow diagrams](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/User-Flow-Diagrams)
-    1. [UI & UX designs](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/UI-&-UX-Designs)
-    1. [Functional Requirements](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Functional-Requirements-with-BDD), expressed as:
+    1. [Problem Statement](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
+    1. [Value Proposition](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
+    1. [Solution Executive Summary](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
+    1. [User Flow diagrams](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/User-Flow-Diagrams)
+    1. [UI & UX designs](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/UI-&-UX-Designs)
+    1. [Functional Requirements](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Functional-Requirements-with-BDD), expressed as:
         1. BDD Scenarios
         1. BDD Business Rules
     1. Non-functional requirements including:
-        1. [Non-functional acceptance criteria](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Non%2DFunctional-Requirements) (above and beyond platform-wide standards)
-        1. [Privacy Impact Assessment](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Privacy-Impact-Assessments)*
-        1. [Security Impact Assessment](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Security-Impact-Assessment)*
-        1. [Accessibility Impact Assessment](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Accessibility-Impact-Assessment)*
+        1. [Non-functional acceptance criteria](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Non%2DFunctional-Requirements) (above and beyond platform-wide standards)
+        1. [Privacy Impact Assessment](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Privacy-Impact-Assessments)*
+        1. [Security Impact Assessment](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Security-Impact-Assessment)*
+        1. [Accessibility Impact Assessment](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Accessibility-Impact-Assessment)*
     1. [Architectural design]()
-    1. [Risks, Assumptions, Issues, and Dependencies](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Risk,-Assumptions,-Issues,-&-Dependencies)
+    1. [Risks, Assumptions, Issues, and Dependencies](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Risk,-Assumptions,-Issues,-&-Dependencies)
     1. Rationalisation - any sporting information that provides context to the artefacts above (for example, a decision log)
 
 

--- a/docs/Delivery-Practices/Design-and-Definition/Definition-of-Ready/Defining-Technical-Improvements.md
+++ b/docs/Delivery-Practices/Design-and-Definition/Definition-of-Ready/Defining-Technical-Improvements.md
@@ -16,17 +16,17 @@ Ready Features and Change Backlog Items should:
 
 1. Meet [INVEST](https://www.agilealliance.org/glossary/invest/) criteria and 
 1. Include the following artefacts:
-    1. [Problem Statement](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
-    1. [Value Proposition](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
-    1. [Solution Executive Summary](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
+    1. [Problem Statement](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
+    1. [Value Proposition](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
+    1. [Solution Executive Summary](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Problem,-Value,-Solution-Statements)
    1. Measures for success and mechanisms for producing metrics
    1. Technical requirements, such as:
        1. Behaviours needed from tools and teams
     1. Non-functional requirements including:
-        1. [Non-functional acceptance criteria](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Non%2DFunctional-Requirements) (above and beyond platform-wide standards)
-        1. [Privacy Impact Assessment](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Privacy-Impact-Assessments)*
-        1. [Security Impact Assessment](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Security-Impact-Assessment)*
-        1. [Accessibility Impact Assessment](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Accessibility-Impact-Assessment)*
+        1. [Non-functional acceptance criteria](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Non%2DFunctional-Requirements) (above and beyond platform-wide standards)
+        1. [Privacy Impact Assessment](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Privacy-Impact-Assessments)*
+        1. [Security Impact Assessment](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Security-Impact-Assessment)*
+        1. [Accessibility Impact Assessment](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Accessibility-Impact-Assessment)*
     1. [Architectural design]()
-    1. [Risks, Assumptions, Issues, and Dependencies](/4.-Backlog-Management/3-Amigos-&-Readying-Backlog-Items/Risk,-Assumptions,-Issues,-&-Dependencies)
+    1. [Risks, Assumptions, Issues, and Dependencies](/Delivery-Practices/Design-and-Definition/3-Amigos-&-Readying-Backlog-Items/Risk,-Assumptions,-Issues,-&-Dependencies)
     1. Rationalisation - any sporting information that provides context to the artefacts above (for example, a decision log)

--- a/docs/Delivery-Practices/Design-and-Definition/Definition-of-Ready/index.md
+++ b/docs/Delivery-Practices/Design-and-Definition/Definition-of-Ready/index.md
@@ -23,9 +23,9 @@ Each backlog item type will have it's own DOR, and corresponding artefacts.
 1. [Features and Changes](Defining-Features-and-Changes/)
 1. [Technical Improvements](Defining-Technical-Improvements/)
 
-Information regarding producing each artefact type can be found within the [3 Amigos & Readying Backlog Items](/4.-Backlog-Management/3-Amigos-%26-Readying-Backlog-Items/) section.
+Information regarding producing each artefact type can be found within the [3 Amigos & Readying Backlog Items](/Delivery-Practices/Design-and-Definition/3-Amigos-%26-Readying-Backlog-Items/) section.
 
-> Note: The Definition of Ready should be considered a guide rather than a set of hard rules. The artefacts actually needed will vary depending on the nature of the backlog item. It is up to the [3 Amigos team](/4.-Backlog-Management/3-Amigos-%26-Readying-Backlog-Items/) to determine what readiness means for each backlog item as they go through the definition processes.
+> Note: The Definition of Ready should be considered a guide rather than a set of hard rules. The artefacts actually needed will vary depending on the nature of the backlog item. It is up to the [3 Amigos team](/Delivery-Practices/Design-and-Definition/3-Amigos-%26-Readying-Backlog-Items/) to determine what readiness means for each backlog item as they go through the definition processes.
 
 # Backlog Prioritisation
 `// TODO:  describe impact & urgency ranking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ extra_javascript:
   - https://unpkg.com/mermaid@9.3.0/dist/mermaid.min.js
 plugins:
   - awesome-pages
+  - search
 theme:
   logo: assets/images/AM no tag.png
   name: material


### PR DESCRIPTION
## Investigations
- New `check-broken-links.yml` workflow
- Trigger check on pull request (disabled in favour of manual triggering)
- Uses [Markdown Link Check](https://github.com/marketplace/actions/markdown-link-check) action

Ultimately abandoned as this cannot cope with URLs that don't match file paths precisely. E.g. converting a URL such as `/engineering/quality-standards/` could potentially map to one of two file paths:

- `/engineering/quality-standards/index.md`
- `/engineering/quality-standards.md`

Future work could be done to extend/re-implement this approach, however it would require writing our own code.

## Link fixing
Whilst the investigation has been shelved, and the workflow disabled from running automatically - this PR also contains a bunch of link fixes that were performed whilst investigating behaviour, and do have value.