### PR TITLE
Fix the scripts and add instructions for running locally

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "command": "call run.bat",
+            "command": "./run.bat",
             "name": "Run Playbook using MKdocs",
             "request": "launch",
             "type": "node-terminal"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Running locally requires the following tooling to be installed and available:
 - [Python](https://www.python.org/downloads/)
 - [pip](https://pypi.org/project/pip/)
 
+To install pip, ensure that Python has been installed and then run `python -m ensurepip`. This will ensure pip is installed and available.
 
 #### Starting and Stopping
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To achieve this you will need to clone the repository and run Playbook on your l
 Running locally requires the following tooling to be installed and available:
 
 - [Visual Studio Code](https://code.visualstudio.com/)
+- [Python](https://www.python.org/downloads/)
 - [pip](https://pypi.org/project/pip/)
 
 

--- a/run.bat
+++ b/run.bat
@@ -1,5 +1,5 @@
 echo off
-pip install mkdocs-material
-pip install mkdocs-awesome-pages-plugin
-mkdocs serve
+py -m pip install mkdocs-material
+py -m pip install mkdocs-awesome-pages-plugin
+py -m mkdocs serve
 exit


### PR DESCRIPTION
Updated the requirements by specifying that Python is installed and then recommending that the pip module is installed.

The launch command and run script has then been updated to use this pip module and remove the need for the call command which does not work with all terminals.