### PR TITLE
Add toolkit experiments and hitsquads

### DIFF
--- a/docs/Ways-of-Working/Toolkit/Community-of-Practice.md
+++ b/docs/Ways-of-Working/Toolkit/Community-of-Practice.md
@@ -1,0 +1,24 @@
+---
+title: Community of Practice
+tags: 
+ - Default
+ - Community of Practice
+---
+
+!!! note "Stub"
+    This page is currently a stub, and requires further expansion
+
+## Communities of Practices
+
+Communities of Practice (or CoPs) are derived from the [Scaled Agile Framework (SAFe)](https://scaledagileframework.com/communities-of-practice/), which describes them as groups with a common interest in a technical or business issue, and who collaborate to share information, skills, and ideas in order to mutually develop their mastery.
+
+We can develop this idea to cover two areas:
+
+1. core departmental competencies, which covers the primary skill areas within the department, such as product management, software development, testing, design
+2. emergent competencies, which covers newly developed or learnt skill or knowledge areas which may later become part of core departmental competencies, such as security testing, behaviour driven development, editorial production workflows, estimation
+
+!!! note 
+    Communities of Practice, Centres of Excellence, and Special Interest Groups are various terms for similar principles. Here we are simplifying this into singular term. 
+    References: 
+       - https://enterprise-knowledge.com/the-difference-between-organizational-community-programs-cop-coe-erg-sig/
+       - https://www.pmi.org/disciplined-agile/people/centers-of-excellence

--- a/docs/Ways-of-Working/Toolkit/Community-of-Practice.md
+++ b/docs/Ways-of-Working/Toolkit/Community-of-Practice.md
@@ -3,6 +3,7 @@ title: Community of Practice
 tags: 
  - Default
  - Community of Practice
+ - Draft
 ---
 
 !!! note "Stub"

--- a/docs/Ways-of-Working/Toolkit/Hit-Squads.md
+++ b/docs/Ways-of-Working/Toolkit/Hit-Squads.md
@@ -1,0 +1,159 @@
+---
+title: Hit Squads
+tags: 
+ - Default
+ - Hit-Squads
+---
+
+
+## Hit Squads
+
+A hit squad is a cross-team group of individuals focussed on solving *high priority*, *well-defined* *ways of working problems*.
+
+A *ways of working problem* could be anything that affects the department’s practices and capabilities. 
+
+*Priority* of problems is relative, but should consider the impact of the problem (and its solution), as well as the urgency, where compared to other known problems that need solving. Priorities will change continuously, and therefore a hit squad must readily review priorities, and pause or cancel their programme of work.
+
+## Commencing Hit Squads
+
+Anyone can create a hit squad, at any time. However, the following principles must be followed:
+
+- The problem must be *well defined*, meaning it is:
+    1.	Clear – it is described using plain and simple language, and is unambiguous. It describes a problems that needs solving, not a solution.
+    2.	Specific – it is a single and discrete problem, not a general theme or idea.
+    3.	Aligned – the group are aligned that this is the problem that the group must solve.
+- Priority is determined:
+    - Key stakeholders, typically including members of the department leadership, agree that this problem needs solving and should take priority over other problems
+    - There are enough team members interested, able, and committed solving this problem as a priority, taking into consideration their other work commitments.
+- Membership and sponsorship must be identified (see [Ownership](#Ownership))
+- Documentation must be maintained: the purpose, plan, and status of the hit squads activities must be kept updated.
+
+## Creating Solutions
+
+The fundamental goal of a hit squad is to solve a problem, however, it likely to be necessary to perform experiments in order to determine the best solution/s to the problem.
+
+!!! toolkit "Experiments"
+
+    <!-- material/tags { include: [Experiments] } -->
+
+Following the conclusion of an experiment, the hit squad will determine whether further experimentation is required, or whether an acceptable solution has been found. 
+
+The outcomes of this may include:
+
+1.	Creation and/or cessation of mechanisms for the Ways of Working toolkit, which may be determined to be “Defaults”
+2.	Training, knowledge sharing, and/or the creation of a [Community of Practice](../Toolkit/Community-of-Practice.md).
+3.	The adoption and/or retiring of software tools.
+
+## Concluding Hit Squads
+
+A Hit Squad may conclude (come to an end) for several reasons, such as:
+
+1.	A solution has been found and agreed upon
+2.	No viable solution has been found, and the problem is determined to be unsolved.
+3.	The problem has gone away or is no longer a priority
+
+The members of a hit squad are responsible for reaching a conclusion and ending their activities. They are also responsible for documenting the hit squad activities and outcomes, and communicating the conclusion to the department. 
+
+The [sponsor](#Ownership) can support the team in reaching a conclusion, and may request that the hit squad concludes if they become aware of concerns or issues with or surrounding the hit squad's activities.
+
+## Ownership
+
+| Owner                 | Responsibility |
+|---|---|
+| Hit Squad Owner       | One specific hit squad member. **Responsible** for ensuring that the hit squad perform their activities, particularly communication and consultation with stakeholders. |
+| Hit Squad             | **Responsible** for scoping, planning, conducting the hit squad, and documenting and communicating all plans and outcomes. |
+| Hit Squad Sponsor     | A DMT or LG member who acts as *primary stakeholder* and consultant to the hit squad and supports the team with decision making. |
+
+## Suggested Flow
+
+The members of a hit squad can conduct their actions as they see fit, this suggested flow aims to provide a starting point if you are not sure what to do. You may well need to adapt this as your situation requires.
+
+Before kick-off, two of more team members will have decided that a problem may benefit from a hit squad. They will have a simple understanding of what the problem is, but may not have defined it fully. They may already have a sponsor and 
+
+Between each stage, consult with stakeholders and evaluate priority and viability, and whether the hit squad should continue, change course, or conclude. In this suggested flow, stakeholders includes the hit squad sponsor.
+
+1.	Define and align
+
+    1. Produce a well-defined problem, and ensure everyone is aligned. Determine:
+         - the value of solving the problem
+         - impact and urgency, and priority
+         - stakeholders
+         - [membership, ownership, and sponsorship](#Ownership)
+    2. Document and seek feedback from stakeholders. 
+
+2.	Determine an objective and simple success measures
+
+    1. Identify what success means for solving this problem, and how it can be measured. Keep it simple and achievable. Consider qualitative and quantitative measures. 
+    1. Document and seek feedback from stakeholders.
+
+3.	Ideate
+    1. Ensure sufficient research and knowledge acquisition is performed. Identify SMEs in the department. Identify resources.
+    2. Identify possible solutions to the problem. Use structured workshops where possible.
+    3. Present proposals to stakeholders and seek feedback.
+    4. Iterate the above until you have converged on a small number of proposed solutions.
+   
+4.	Experiment
+
+    Perform [structured experiments](../Toolkit/Structure-Experiments.md) to validate (or disprove) proposed solutions. This may be a single experiment, a series of experiments, or experiments run in parallel.
+
+5.	Review
+
+    Share the outcome of the experiments with stakeholders. 
+
+    Has this experiment successfully solved the problem? Have your success criteria been satisfactorily met? Do they need to be modified based on what you have learnt.
+
+6.	Iterate
+
+    Iterate through the ideation and experimentation as appropriate.
+
+7.	Conclude
+
+    Wrap up the hit squad once a conclusion has been made, ensuring that a plan is in place for communicating the conclusion, and implementation, including knowledge sharing, or training.
+
+## Tips
+
+**Be quick.** Hit squads should aim to be as short lived as possible. This can be enabled by:
+
+1.	Focus and simplicity: make sure the problem and objective is clear and small. Larger problems are more complex and harder to solve, require a larger time commitment. 
+2.	A  bias towards action: avoid decision paralysis and over preparation: find the smallest, simplest action that can be taken rapidly, then iterate fast. 
+3.	Short, quick experiments create learnings faster. Avoid long running experiments that produce no insights or outcomes for long periods.
+
+**Avoid waste.** Your time is limited and valuable, use it carefully:
+
+- A little research goes a long way. Don’t rely on assumptions or past experiences alone.
+- Measuring success and performing experiments is time consuming, keep them simple and achievable, and prioritise carefully.
+  
+**Failure is good, iteration is great.**
+
+- Experiments may fail, and that is OK. It is perfectly valid to disprove a solution.
+- Create success metrics before defining the experiments, to avoid creating biases.
+- The objective may well aim for a first iteration of a solution, upon which there will be continuous improvement.
+
+## Objective Examples
+
+### Simple Objective
+
+**Problem:** It isn’t clear who has read RFCs
+
+**Objective:** Create a mechanism for identifying when RFCs have been by relevant stakeholders.
+
+**Success Measures:**
+
+1.	RFC creators can find out who has read the document, regardless of whether they provided feedback, without having to ask around
+2.	Business stakeholders identify an improvement in RFC visibility
+
+### Using OKRs
+
+In this example, the same discrete problem links to other problems, and so a higher level objective could be determined. Which may have numerous key results. This Hit Squad identify the first key result, and this becomes the focussed goal of the hit squad. Later or concurrent hit squads could tackle other key results for the same objective.
+
+**Problem:** It isn’t clear who has read RFCs
+
+**Objective:** Improve RFC engagement
+
+**Key Result:** Create a mechanism for identifying when RFCs have been by relevant stakeholders.
+
+**Success Measures:**
+
+1.	RFC creators can find out who has read the document, regardless of whether they provided feedback, without having to ask around
+2.	Business stakeholders identify an improvement in RFC visibility
+

--- a/docs/Ways-of-Working/Toolkit/Structure-Experiments.md
+++ b/docs/Ways-of-Working/Toolkit/Structure-Experiments.md
@@ -1,0 +1,103 @@
+---
+title: Structured Experiments
+tags: 
+ - Default
+ - Experiments
+---
+
+Experiments are used to enable continuous improvement by producing insights that can lead to incremental change. Any team or individual can conduct an experiment. As we continue to learn from our experiences, everything we do can be considered an experiment. 
+
+*Structured Experiments*, are purposeful and targeted experiments, with specific purposes and defined parameters.
+
+Experimentation can be time consuming and costly, so it is important to ensure they are performed effectively, with minimal waste, and that the insights produced are maintained.
+
+## Performing Structured Experiments 
+
+Anyone can perform a Structured Experiment. Typical scenarios include:
+
+1.	A team have identified a constraint and have an idea of how to remove it
+2.	A hit squad are working on solving an inter-team problem, and have identified a possible solution
+3.	An individual wants to try a new approach to personal work, and wants to share their learnings
+
+Structured Experiments can be performed at any time, so long as those impacted by the experiment are aware and have agreed with the proposed approach, and that the experiment does not knowingly [negatively impact another experiment or area of work](#pollution). Be mindful of introducing WIP, and the burden of additional cognitive load.
+
+### Structure
+
+A Structured Experiment requires the following parameters, actions, and outputs:
+
+#### Parameters
+
+- **Objective:** what we are looking to learn, what problem are we solving
+- **Hypothesis:** what we are expecting to happen given specific experiment being performed, including success criteria.
+- **Definition:** what the experiment be testing, and how the experiment will run, e.g.:
+     - [Who will be involved](#ownership)
+     - The mechanisms are being used
+- **Timeframe:** the start and end of the experiment
+- **Ownership:** those who will be [responsible](#ownership) for creating and performing this experiment, and who will be accountable for its outcomes?
+  
+#### Actions
+
+- **Planning:** Structured Experiments require planning to ensure that they are able to be successful.
+- **Monitoring:** Structured Experiments require data to be gathered, as well as oversight to ensure that they are running effectively.
+- **Analysis:** Data and outcomes must be analysed in order to produce insights. Analysis should include environmental influences.
+- **Conclusion:** 
+      - Summarises the [outcome](#outcomes-from-structured-experiments), determining whether the hypothesis has been proven or disproven, and whether the experiment has been successful or not. 
+      - Makes recommendations for next steps.
+- **Knowledge Sharing:** Stakeholders must be appraised of the conclusion, and this information must be made accessible for future review.
+
+#### Outputs
+
+- **Documentation** including:
+    - All experiment parameters, which will provide a complete written summary of the experiment that has been/will be performed
+    - Data captured and analysis notes
+    - Conclusion report
+
+### Pollution
+
+Interactions between activities may cause unintended side affects, or pollution. It is important to consider:
+
+1.	How will this experiment interact with other experiments.
+
+    Running multiple experiments concurrently may make it impossible to identify which experiment caused what outcome. Consider overlapping areas of concern between experiments, and how they are timed. 
+
+    Additionally, multiple experiments can reduce focus, cause confusion, and reduce buy in.
+
+2.	How will this experiment interact with other work.
+
+    It is important to be aware if there is sensitive, complex, or time critical work in progress or upcoming which may negatively impact, or be impacted by, an experiment. 
+
+## Outcomes from Structured Experiments
+
+Successful experiments are experiments that produce useful insights in an effective way. This means that the experiment may prove or disprove a hypothesis, and still be considered successful.
+
+There are therefore 3 primary outcomes:
+
+1.	Success, hypothesis proven
+2.	Success, hypothesis disproven
+3.	Failure, experiment unable to prove or disprove hypothesis
+
+Whichever outcome, it is important that the learnings are captured and made available for future use. As experiments are subject to the environmental conditions, it is critical that as much of the environmental context is also captured.
+
+It is especially important that when an experiment concludes with failure, that the reasons for failure are determined and communicated.  
+
+## Ownership
+
+| Owner                 | Responsibility |
+|---|---|
+| Experiment Team       | **Responsible** for defining [parameters](#parameters), performing or coordinating [actions](#actions), and producing [outputs](#outputs). **Accountable** for the outcome. |
+| Participants      | **Responsible** for participating in the experiment, performing the [actions](#actions) and providing feedback or producing data. |
+
+## Suggested Flow
+
+1. Scope: Set out the objective and define a hypothesis. This process may require research and iterative discussion, in order to align on the most valuable scope. Remember that a hypothesis requires success criteria. This is a sensible time to determine ownership.
+2.	Plan: Define the solution being experimented and set out the practical parameters of the experiment: 
+     1.	who is involved? 
+     1.	what is being done? 
+     1.	when will it start?
+     1.	when will it finish?
+     1.	how will it be measured / how is information gathered?
+3.	Commence: Start the experiment
+4.	Monitor: monitor the experiment to ensure it is running correctly, gather data
+5.	Analyse: once enough data is collected, analyse it
+6.	Conclude and Share: determine conclusions, and present findings to stakeholders
+7.	Iterate: This experiment is now over. Is further learning needed? Are more experiments required?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_dir: site
 repo_url: https://github.com/amdigital-co-uk/docs-playbook
 repo_name: AM/Playbook
 edit_uri: edit/main../../
+site_url: !ENV ["siteurl"]
 extra_css:
   - stylesheets/extra.css
 extra_javascript:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_dir: site
 repo_url: https://github.com/amdigital-co-uk/docs-playbook
 repo_name: AM/Playbook
 edit_uri: edit/main../../
-site_url: !ENV ["siteurl"]
+site_url: !ENV ["SITE_URL"]
 extra_css:
   - stylesheets/extra.css
 extra_javascript:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_dir: site
 repo_url: https://github.com/amdigital-co-uk/docs-playbook
 repo_name: AM/Playbook
 edit_uri: edit/main../../
-site_url: !ENV ["SITE_URL"]
+site_url: !ENV [SITE_URL, 'https://playbook.platformdev.amdigital.co.uk/']
 extra_css:
   - stylesheets/extra.css
 extra_javascript:


### PR DESCRIPTION
I have created these pages as per my earlier word document, with a few amends, taking into account the feedback provided then.

I have additionally created a stub for a Communities of Practice page, which I propose serves as a replacement for the Centre of Excellence terminology. As it happens, much of my reading on this topics indicates that this is more appropriate terminology anyway. @alexrae87 will be picking that put and sharing thoughts at a later date, I have created a stub for now and marked it as draft. **Therefore no need to review the Communities of Practice page as part of this PR.**