### PR TITLE
Playbook local running fix

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -24,6 +24,10 @@ jobs:
           pip install mkdocs-git-revision-date-localized-plugin
           pip install mkdocs-git-committers-plugin-2
       
+      - name: Enable insiders-only config
+        run: |
+          sed -i mkdocs.yml -e "s/#insiders-only#//g"
+
       - name: Deploy MKdocs site
         run: |
           mkdocs build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,21 +5,9 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "command": "run.bat",
+            "command": "call run.bat",
             "name": "Run Playbook using MKdocs",
-            "command": "mkdocs serve",
-            "name": "Install and run",
-            "request": "launch",
-            "type": "node-terminal",
-            "preLaunchTask": "Install",
-        
-        },        
-        {
-            "command": "mkdocs serve",
-            "name": "Run",
             "request": "launch",
             "type": "node-terminal"
-        }
-        
-    ]
+        }]
 }

--- a/docs/Ways-of-Working/Governance/Problem-Governance/.pages
+++ b/docs/Ways-of-Working/Governance/Problem-Governance/.pages
@@ -2,7 +2,6 @@ nav:
 - index.md
 - Problem-Discovery.md
 - Problem-Definition.md
-- Challenge-Mapping.md
 - Requirements-Gathering.md
 - Solution-Design.md
 - Success-Planning.md

--- a/install-and-run.bat
+++ b/install-and-run.bat
@@ -1,0 +1,10 @@
+@echo off
+py -m pip install mkdocs-material
+py -m pip install mkdocs-awesome-pages-plugin
+py -m pip install mkdocs-blog-plugin
+py -m pip install mkdocs-glightbox
+py -m pip install mkdocs-git-revision-date-localized-plugin
+py -m pip install mkdocs-git-committers-plugin-2
+
+py -m mkdocs serve
+exit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,9 @@
+# NOTE - Some features are MKDocs insiders only!
+#
+# Some plugins/config will only work if the mkdocs-material-insiders module is installed, which cannot be done locally.
+# Any such config should be disabled locally by prepending the following without quotes/spaces: '#insiders-only#'
+# The pipeline will re-enable any insiders-only config lines before building and publishing
+
 site_name: Platform Development Playbook
 site_dir: site
 repo_url: https://github.com/amdigital-co-uk/docs-playbook
@@ -13,7 +19,7 @@ plugins:
   - search
   - tags
   - glightbox
-  - meta
+  #insiders-only#- meta
   - git-revision-date-localized:
       enable_creation_date: true      
       enabled: !ENV [CI, false]

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,5 @@
+@echo off
+
+echo If this is your first time running, you will need to manually run `install-and-run.bat`
+
+py -m mkdocs serve

--- a/run/install-and-run.bat
+++ b/run/install-and-run.bat
@@ -1,7 +1,0 @@
-@echo off
-py -m pip install mkdocs-material --upgrade
-py -m pip install mkdocs-awesome-pages-plugin
-py -m pip install mkdocs-glightbox
-py -m mkdocs serve
-exit
-

--- a/run/run.bat
+++ b/run/run.bat
@@ -1,3 +1,0 @@
-@echo off
-mkdocs serve
-exit


### PR DESCRIPTION
# Problem Context
The `meta` plugin is only available as part of the Material for MKDocs [insiders program](https://squidfunk.github.io/mkdocs-material/insiders/). Access to this requires sponsoring the relevant GitHub project, and means only one [account within the organisation](https://github.com/AMSharedAdmin) can access the repo. 

For the playbook deployment pipeline, a GitHub PAT grants the relevant workflow access to this dependency, but this approach is not practical for running the playbook locally.

# Solution
The `meta` plugin is not critical, so disabling it locally will not greatly impact authorship experience. This pull request makes the following changes:

Disable the meta plugin locally, whilst enabling it for deployment:
- Prepend a magic comment in front of the plugin config: `#insiders-only#`
- Remove this magic comment in the build pipeline

Simplify local running
- Fix the install and run scripts by moving them into the root of the repo
- Simplify the VSCode debug config (and bring it in-line with the Knowledgebase one)

Finally it also removes an invalid file from one of the `.pages` files.