### PR TITLE
Add CNAME file for custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+playbook.platformdev.amdigital.co.uk


### PR DESCRIPTION
Github requires a CNAME in the branch for a custom domain - every time we publish this get dropped, adding to the MKdocs doc folder so it get published as part of the build.